### PR TITLE
add initial task

### DIFF
--- a/task.yaml
+++ b/task.yaml
@@ -1,0 +1,49 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: ai-triage-failure
+spec:
+  params:
+    - name: tangerine_api_url_secret
+      type: string
+      description: Secret containing the Tangerine API URL
+    - name: tangerine_api_token_secret
+      type: string
+      description: Secret containing the Tangerine API token
+    - name: tangerine_assistant_id
+      type: string
+      description: ID for the chat assistant
+    # TODO: this should contain the prompt and output to triage
+    - name: tangerine_query
+      default: "What is Konflux?"
+  steps:
+    - name: post-build-output
+      image: quay.io/konflux-ci/appstudio-utils:8f9f933d7b0b57e37b96fd34698c92c785cfeadc@sha256:924eb1680b6cda674e902579135a06b2c6683c3cc1082bbdc159a4ce5ea9f4df
+      env:
+        - name: TANGERINE_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.tangerine_api_token_secret)
+              key: tangerine_api_token
+        - name: TANGERINE_API_URL
+          valueFrom:
+            secretKeyRef:
+              name: $(params.tangerine_api_url_secret)
+              key: tangerine_api_url
+      script: |
+        #!/usr/bin/env bash
+
+        set -e
+
+        curl \
+          --silent \
+          --insecure \
+          --output response.json \
+          --request POST \
+          --header "Content-Type: application/json" \
+          --header "Authorization: Bearer ${TANGERINE_API_TOKEN}" \
+          --data '{"query":"$(params.tangerine_query)","stream":"false"}' \
+          "${TANGERINE_API_URL}/assistants/$(params.tangerine_assistant_id)/chat"
+
+        # TODO: check for bad responses
+        jq --raw-output .text_content response.json


### PR DESCRIPTION
needs a secret created:

```
apiVersion: v1
kind: Secret
metadata:
  name: tangerine-api
stringData:
  tangerine_api_url: ...
  tangerine_api_token: ...
```

then running the task:

```
❯ tkn task start -p tangerine_api_url_secret=tangerine-api -p tangerine_api_token_secret=tangerine-api -p tangerine_assistant_id="21" --showlog ai-triage-failure
TaskRun started: ai-triage-failure-run-pw8gj
Waiting for logs to be available...
[post-build-output]  Konflux is a platform that helps teams develop applications. It primarily serves two categories of users: Platform Engineers (PEs) and Developers.
[post-build-output]
[post-build-output] - **Platform Engineers (PEs)** are responsible for managing an instance of Konflux and its users. They manage that instance and its users, and they typically install Konflux before adding users and assigning them to a Konflux workspace.
[post-build-output]
[post-build-output] - **Developers** are the people who engineer applications for their organization. They use Konflux to build, test, and release their applications as ones or more components that run together.
[post-build-output]
[post-build-output] To access Konflux, developers need the URL to their team's instance and their user credentials, provided by the PE. The actions developers can take generally fall into three key categories: Build, Test, and Release.
[post-build-output]
[post-build-output] In the 'Getting started with Konflux' document, you can find detailed information about the roles and responsibilities of PEs and developers, as well as links to further documentation for each role. This document is the most relevant and comprehensive resource for understanding Konflux and its usage.
```

Signed-off-by: Brady Pratt <bpratt@redhat.com>
